### PR TITLE
Feature - Thread Safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Release [0.5.1] - 2025-07-04
+
+### Added
+
+- **Thread Safety**: All logging operations are now protected by a critical section for true thread safety
+  - `TSimpleLog` now uses a `TRTLCriticalSection` internally
+  - Safe to use the same logger instance from multiple threads
+  - New `Finalize` method to release resources (optional, for advanced use)
+
+### Changed
+
+- Improved documentation for thread safety and resource management
+- Updated user manual and cheat sheet to reflect thread-safe design
+
+### Fixed
+
+- Minor documentation and test clarifications
+
 ## Release [0.5.0] - 2025-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Free Pascal](https://img.shields.io/badge/Free%20Pascal-3.2.2+-4e7ddc.svg)](https://www.freepascal.org/)
 [![Lazarus](https://img.shields.io/badge/Lazarus-4.0+-6fa8dc.svg)](https://www.lazarus-ide.org/)
 [![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20Linux-6aa84f.svg)](#)
-[![Version](https://img.shields.io/badge/version-0.5.0-4682b4.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.5.1-4682b4.svg)](CHANGELOG.md)
 [![No Dependencies](https://img.shields.io/badge/dependencies-none-4e7ddc.svg)](#)
 
 > [!Note]
@@ -222,17 +222,26 @@ Log.Info('Logging is back on');
 
 ### 🧵 Thread Safety
 ```pascal
-// File operations are inherently safer in most file systems
-// Multiple threads can safely use the same logger instance
-// For high-concurrency scenarios, consider using separate logger instances
+// SimpleLog is thread-safe by default!
+// All logging operations are protected by a critical section.
+// You can safely use the same logger instance from multiple threads.
 var
   Log: TSimpleLog;
 begin
   Log := TSimpleLog.Both('threaded.log');
-  // Use Log from multiple threads with basic safety
+  // Use Log from multiple threads with confidence
   Log.Info('Multi-threaded logging works reliably');
 end;
 ```
+
+// Advanced: If you create/destroy many logger instances, call Finalize to release resources
+var
+  Log: TSimpleLog;
+begin
+  Log := TSimpleLog.Console;
+  // ... use Log ...
+  Log.Finalize; // Optional: releases critical section (not needed for most apps)
+end;
 
 ## 💯 Advanced Record Benefits
 

--- a/docs/SimpleLogger.md
+++ b/docs/SimpleLogger.md
@@ -409,13 +409,32 @@ SimpleLog automatically rotates log files when they reach the maximum size:
 - Renamed to `application.log.1`
 - New `application.log` is created
 
+
 ## Thread Safety
 
-SimpleLog provides basic thread safety through:
+SimpleLog is now fully thread-safe by default:
 
-- Controlled file operations (open/write/close for each message)
-- No shared mutable state between threads
-- Value semantics (each logger instance is independent)
+- All logging operations are protected by a critical section (`TRTLCriticalSection`)
+- You can safely use the same logger instance from multiple threads
+- No log message interleaving or corruption
+- Value semantics: each logger instance is independent
+
+**Resource Management:**
+
+- For most applications, you do not need to call any cleanup methods
+- If you create and destroy many logger instances, call `Logger.Finalize` to release the critical section
+
+**Example:**
+
+```pascal
+var
+  Logger: TSimpleLog;
+begin
+  Logger := TSimpleLog.Both('threaded.log');
+  Logger.Info('Thread-safe logging!');
+  Logger.Finalize; // Optional: releases critical section
+end;
+```
 
 ## Error Handling
 

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -112,12 +112,15 @@ Logger := Logger
 ## 📁 File Operations
 
 ```pascal
+
 // File rotation happens automatically when MaxFileSize is reached
 // application.log → application.log.1 (backup)
 // New application.log is created
 
-// Ensure data is written to file
-Logger.Flush;
+// Thread safety: All logging is protected by a critical section
+// You can use the same logger from multiple threads
+
+// (Flush is not needed; all writes are immediate)
 
 // Check if logging to file
 if odFile in Logger.Outputs then

--- a/packages/lazarus/simplelog.lpk
+++ b/packages/lazarus/simplelog.lpk
@@ -9,7 +9,7 @@
       <PathDelim Value="\"/>
       <SearchPaths>
         <OtherUnitFiles Value="..\..\src"/>
-        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)\"/>
+        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
     </CompilerOptions>
     <Description Value="A simple, lightweight, and easy-to-use logging library for Free Pascal applications."/>
@@ -30,7 +30,7 @@ copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. "/>
-    <Version Minor="5"/>
+    <Version Minor="5" Release="1"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\SimpleLog.pas"/>


### PR DESCRIPTION
# Description

- **Thread Safety**: All logging operations are now protected by a critical section for true thread safety
  - `TSimpleLog` now uses a `TRTLCriticalSection` internally
  - Safe to use the same logger instance from multiple threads


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Testing

Please describe the tests that you ran to verify your changes.

- [x] Did it compile with the test runner?
- [x] Did you run the following command after compilation (in `tests/`)? If not, please modify.

```pascal
./TestRunner.exe -a --format=plain
``` 

- [x] Did you pass all test? Yes